### PR TITLE
feat: Use watershed to find wires

### DIFF
--- a/src/tasks/wire_color.py
+++ b/src/tasks/wire_color.py
@@ -6,6 +6,9 @@ import numpy as np
 from colormath import color_diff
 from colormath.color_objects import LabColor
 
+# LAB representation of white color
+WHITE_LAB_COLOR = cv2.cvtColor(np.full((1, 1, 3), 255, dtype=np.uint8), cv2.COLOR_BGR2LAB)[0, 0, :]
+
 DEFAULT_ACCEPTABLE_DELTA_E_THRESHOLD = 4  # Default threshold to consider two colors equal
 
 
@@ -15,8 +18,14 @@ def find_wire_lab_color(wire_img: np.ndarray) -> Tuple[float, float, float]:
     The representative LAB value is the median of the mean LAB values of the bins,
     where a bin is taken as one pixel column in the `wire_img`.
     """
-    # Convert the wire image to hsv color space
+    # Convert the wire image to LAB color space
     wire_lab: np.ndarray = cv2.cvtColor(wire_img, cv2.COLOR_BGR2LAB)
+
+    # Change wire image value type to float to be able to use NaN
+    wire_lab = wire_lab.astype(np.float16)
+
+    # Fill in the background color (complete white) as NaN value
+    wire_lab[wire_lab == WHITE_LAB_COLOR] = np.nan
 
     # Initiate lists to store the mean hsv values of all the bins
     l_bin_vals = []
@@ -26,9 +35,9 @@ def find_wire_lab_color(wire_img: np.ndarray) -> Tuple[float, float, float]:
     # Iterate through each bin (1 px column) in the wire image
     for bin in range(wire_lab.shape[1]):
         # Find the average hsv value of the bin
-        bin_avg_l_val = np.mean(wire_lab[bin, :, 0])
-        bin_avg_a_val = np.mean(wire_lab[bin, :, 1])
-        bin_avg_b_val = np.mean(wire_lab[bin, :, 2])
+        bin_avg_l_val = np.nanmean(wire_lab[:, bin, 0])
+        bin_avg_a_val = np.nanmean(wire_lab[:, bin, 1])
+        bin_avg_b_val = np.nanmean(wire_lab[:, bin, 2])
 
         # Add the hsv value to the bin values lists
         l_bin_vals.append(bin_avg_l_val)
@@ -36,9 +45,9 @@ def find_wire_lab_color(wire_img: np.ndarray) -> Tuple[float, float, float]:
         b_bin_vals.append(bin_avg_b_val)
 
     # Calculate the median of the mean hsv values to get representative hsv value
-    representative_l_val = np.median(l_bin_vals)
-    representative_a_val = np.median(a_bin_vals)
-    representative_b_val = np.median(b_bin_vals)
+    representative_l_val = np.nanmedian(l_bin_vals)
+    representative_a_val = np.nanmedian(a_bin_vals)
+    representative_b_val = np.nanmedian(b_bin_vals)
 
     return representative_l_val, representative_a_val, representative_b_val
 

--- a/src/tasks/wires.py
+++ b/src/tasks/wires.py
@@ -5,10 +5,17 @@ from typing import List
 import cv2
 import numpy as np
 
-from ..utils import contour_utils, frame_utils, rect_utils
+from ..utils import frame_utils, rect_utils
 
 DISPLAY_WIRES_WINDOW_NAME = "wires"
 MINIMUM_VALID_WIRE_CONTOUR_AFTER_ERODE = 100
+
+# The pixel distance from background in proportion to the max pixel distance
+# to consider that pixel as foreground.
+# E.g., If max pixel distance from background is 10 px, then the pixel distance
+#       from background must be  >= WIRE_SURE_FG_DISTANCE_PROPORTION * 10 for that
+#       pixel to be considered a foreground.
+WIRE_SURE_FG_DISTANCE_PROPORTION = 0.7
 
 
 def get_wire_from_contour(wire_roi_img: np.ndarray, wire_contour: np.ndarray) -> np.ndarray:
@@ -39,6 +46,41 @@ def get_wire_from_contour(wire_roi_img: np.ndarray, wire_contour: np.ndarray) ->
     )
 
 
+def get_watershed_labels(wire_roi_img: np.ndarray, wire_roi_thresh: np.ndarray) -> np.ndarray:
+    """Get the watershed labeling separating the background and each foreground object.
+
+    Logic is adapted from https://docs.opencv.org/4.x/d3/db4/tutorial_py_watershed.html
+    """
+    # Set up configuration and noise removal
+    kernel = np.ones((3, 3), np.uint8)
+    wire_roi_thresh_noise_remove = cv2.morphologyEx(wire_roi_thresh, cv2.MORPH_OPEN, kernel, iterations=2)
+
+    # Expand the foreground in order to get the sure bg as black
+    sure_bg = cv2.dilate(wire_roi_thresh_noise_remove, kernel)
+
+    # Find the sure foreground area
+    distance_transform: np.ndarray = cv2.distanceTransform(wire_roi_thresh_noise_remove, cv2.DIST_L2, 5)
+    _, sure_fg = cv2.threshold(distance_transform, WIRE_SURE_FG_DISTANCE_PROPORTION * distance_transform.max(), 255, 0)
+    sure_fg: np.ndarray = sure_fg.astype(np.uint8)
+
+    # Find unknown region
+    unknown = cv2.subtract(sure_bg, sure_fg)
+
+    # Watershed markers labelling
+    _, markers = cv2.connectedComponents(sure_fg)
+
+    # Add one to all labels so that sure background is not 0, but 1
+    markers = markers + 1
+
+    # Mark the region of unknown with zero
+    markers[unknown == 255] = 0
+
+    # Apply watershed
+    watershed_labels: np.ndarray = cv2.watershed(wire_roi_img, markers)
+
+    return watershed_labels
+
+
 def find_wires(wire_roi_img: np.ndarray, do_display_wires_thresh: bool = False) -> List[np.ndarray]:
     """Find the wires located inside the wire region of interest."""
     # Add padding to the wire region of interest, so no information will be lost if roi is rotated
@@ -48,28 +90,35 @@ def find_wires(wire_roi_img: np.ndarray, do_display_wires_thresh: bool = False) 
     wire_roi_gray = cv2.cvtColor(wire_roi_img, cv2.COLOR_BGR2GRAY)
     _, wire_roi_thresh = cv2.threshold(wire_roi_gray, 254, 255, cv2.THRESH_BINARY_INV)
 
-    # Set up configuration for erosion
-    kernel = np.ones((3, 3), np.uint8)
-    iterations = 6
+    watershed_labels = get_watershed_labels(wire_roi_img, wire_roi_thresh)
 
-    # Perform erosion to reduce probability that wires will touch each other
-    # Erosion also reduces the roi of each wire, ensuring we are inspecting the wire and not its edge
-    erode_thresh = cv2.erode(wire_roi_thresh, kernel, iterations=iterations)
+    # Initiate list to keep found wire contours
+    wire_contours = []
 
-    # Filter out contours that are likely not wires
-    wires_thresh = contour_utils.filter_out_small_contours(erode_thresh, MINIMUM_VALID_WIRE_CONTOUR_AFTER_ERODE)
+    # Initiate display wire threshold got from performing watershed
+    display_wire_thresh = np.zeros(watershed_labels.shape, dtype=np.uint8)
 
-    # Perform dilate to get section of wires back
-    wires_thresh = cv2.dilate(wires_thresh, kernel, iterations=int(iterations / 2))
+    # Loop over the unique label returned by watershed algorithm
+    for label in np.unique(watershed_labels):
+        # Bg will have label 1, while outline have label -1, so we ignore all labels below 1
+        if label <= 1:
+            continue
 
+        # Create a mask and draw the found wire on it
+        mask = np.zeros(watershed_labels.shape, dtype=np.uint8)
+        mask[watershed_labels == label] = 255
+
+        # Draw the found wire for display
+        display_wire_thresh[watershed_labels == label] = 215 if label % 2 == 0 else 125
+
+        # Detect the contours in the mask and get the largest contour
+        contours, _ = cv2.findContours(mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+        wire_contour = max(contours, key=cv2.contourArea)
+
+        wire_contours.append(wire_contour)
+
+    # Perform display if needed
     if do_display_wires_thresh:
-        cv2.imshow(DISPLAY_WIRES_WINDOW_NAME, wires_thresh)
+        cv2.imshow(DISPLAY_WIRES_WINDOW_NAME, display_wire_thresh)
 
-    # Find the contours
-    contours, _ = cv2.findContours(wires_thresh, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
-
-    # Sort the contour based on its x axis
-    contours = contour_utils.sort_contours_by_axis(contours, True)
-
-    # Crop a section of wire from each wire contour
-    return [get_wire_from_contour(wire_roi_img, contour) for contour in contours]
+    return [get_wire_from_contour(wire_roi_img, contour) for contour in wire_contours]


### PR DESCRIPTION
## What Changes in this PR?
- Use watershed algorithm to find wires
- Fix wrong connector width and height if first rotation for finding wire roi is wrong
- Correct to checking by column instead of by row when finding wire color
- Disregard white background color when finding wire color